### PR TITLE
Fix memory leak: remove a listener

### DIFF
--- a/src/com/android/incallui/CallButtonPresenter.java
+++ b/src/com/android/incallui/CallButtonPresenter.java
@@ -69,6 +69,7 @@ public class CallButtonPresenter extends Presenter<CallButtonPresenter.CallButto
         AudioModeProvider.getInstance().removeListener(this);
         InCallPresenter.getInstance().removeIncomingCallListener(this);
         InCallPresenter.getInstance().removeDetailsListener(this);
+        InCallPresenter.getInstance().removeCanAddCallListener(this);
     }
 
     @Override


### PR DESCRIPTION
CallButtonPresenter doesn't remove itself from InCallPresenter.CanAddCallListener,
which causes a memory leak.

Change-Id: I3dcfc6aaa26eca3547e95de01b292042e46e30af
